### PR TITLE
Add entity-ids-file search option, fix textfile parsing and HTML map tiles

### DIFF
--- a/usgsxplore/api.py
+++ b/usgsxplore/api.py
@@ -410,6 +410,12 @@ class API:
                         f.write(chunk)
 
     def get_scenes_metadata(self, dataset: str, entity_ids: list[str]) -> list[dict]:
+        """Get full metadata for a list of scenes, identified by entity ID.
+
+        :param dataset: Dataset alias.
+        :param entity_ids: List of entity IDs.
+        :return: List of scene metadata.
+        """
         list_id = datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y%m%d_%H%M%S")
         payload = {
             "listId": list_id,

--- a/usgsxplore/cli.py
+++ b/usgsxplore/cli.py
@@ -56,9 +56,9 @@ def read_dataset_textfile(ctx: click.Context, param: click.Parameter, value: str
     return dataset
 
 
-def is_text_file(ctx: click.Context, param: click.Parameter, value: str) -> str:
+def is_text_file(ctx: click.Context, param: click.Parameter, value: str | None) -> str | None:
     "callback for verify the validity of the textfile"
-    if not value.endswith(".txt"):
+    if value is not None and not value.endswith(".txt"):
         raise click.BadParameter(f"'{value}' must be a textfile", ctx=ctx, param=param)
     return value
 
@@ -78,6 +78,7 @@ def is_vector_file(ctx: click.Context, param: click.Parameter, value: str) -> st
 # 									COMMAND LINE INTERFACE
 # ----------------------------------------------------------------------------------------------------
 @click.group()
+@click.version_option(package_name="usgsxplore")
 def cli() -> None:
     """
     Command line interface of the usgsxplore.
@@ -128,6 +129,13 @@ def cli() -> None:
 )
 @click.option("-f", "--filter", type=click.STRING, help="String representation of metadata filter")
 @click.option("-m", "--limit", type=click.INT, help="Max. results returned. Return all by default")
+@click.option(
+    "-e",
+    "--entity-ids-file",
+    type=click.Path(exists=True, file_okay=True),
+    callback=is_text_file,
+    help="Textfile of entity IDs to fetch metadata for, instead of searching (other filters are ignored).",
+)
 @click.option("--pbar", is_flag=True, default=False, help="Display a progress bar")
 def search(
     dataset: str,
@@ -139,6 +147,7 @@ def search(
     interval_date: tuple[str, str] | None,
     filter: str | None,  # pylint: disable=redefined-builtin
     limit: int | None,
+    entity_ids_file: str | None,
     pbar: bool,
 ) -> None:
     """
@@ -154,6 +163,7 @@ def search(
         interval_date=interval_date or None,
         filter_str=filter,
         limit=limit,
+        entity_ids_file=entity_ids_file,
         show_progress=pbar,
     )
 

--- a/usgsxplore/core.py
+++ b/usgsxplore/core.py
@@ -37,15 +37,20 @@ def search_scenes(
     interval_date: tuple[str, str] | None = None,
     filter_str: str | None = None,
     limit: int | None = None,
+    entity_ids_file: str | None = None,
     show_progress: bool = False,
 ):
     """
     Search scenes in a dataset with optional spatial, temporal, and metadata filters.
 
-    If no output files are provided, entity IDs are printed to stdout.
-    Otherwise, results are saved to the specified files. The output format is
-    inferred from the file extension: .txt (entity IDs), .json (raw metadata),
-    .gpkg/.geojson/.shp (vector), .html (interactive map).
+    If no output files are provided, entity IDs are printed to stdout (or the
+    full metadata as JSON, when entity_ids_file is used). Otherwise, results are
+    saved to the specified files. The output format is inferred from the file
+    extension: .txt (entity IDs), .json (raw metadata), .gpkg/.geojson/.shp
+    (vector), .html (interactive map).
+
+    If entity_ids_file is provided, metadata is fetched for those entity IDs
+    directly instead of running a filtered search, and all other filters are ignored.
 
     Parameters
     ----------
@@ -71,50 +76,61 @@ def search_scenes(
         Metadata filter string (e.g. "camera=H & resolution=6").
     limit : int or None
         Maximum number of scenes to return.
+    entity_ids_file : str or None
+        Path to a textfile of entity IDs (one per line). When given, metadata is
+        fetched for these entity IDs instead of running a filtered search.
     show_progress : bool
         Whether to display a progress bar during search.
     """
-    scene_filter = SceneFilter.from_args(
-        location=location,
-        bbox=bbox,
-        max_cloud_cover=clouds,
-        date_interval=interval_date,
-        meta_filter=filter_str,
-        g_file=vector_file,
-    )
-
     try:
         with API(username, token) as api:
-            if not output_files:
-                for batch in api.batch_search(dataset, scene_filter, limit, "summary", show_progress):
-                    for scene in batch:
-                        print(scene["entityId"])
+            if entity_ids_file:
+                _, entity_ids = utils.read_textfile(entity_ids_file)
+                scenes = api.get_scenes_metadata(dataset, entity_ids)
             else:
+                scene_filter = SceneFilter.from_args(
+                    location=location,
+                    bbox=bbox,
+                    max_cloud_cover=clouds,
+                    date_interval=interval_date,
+                    meta_filter=filter_str,
+                    g_file=vector_file,
+                )
+                if not output_files:
+                    for batch in api.batch_search(dataset, scene_filter, limit, "summary", show_progress):
+                        for scene in batch:
+                            print(scene["entityId"])
+                    return
+
                 # determine metadata type
                 metadata_type = "summary" if len(output_files) == 1 and output_files[0].endswith(".txt") else "full"
                 scenes = []
                 for batch in api.batch_search(dataset, scene_filter, limit, metadata_type, show_progress):
                     scenes += batch
 
-                for file in output_files:
-                    directory = os.path.dirname(file)
-                    if directory:
-                        os.makedirs(directory, exist_ok=True)
+            if not output_files:
+                print(json.dumps(scenes, indent=4))
+                return
 
-                    if file.endswith(".txt"):
-                        with open(file, "w", encoding="utf-8") as f:
-                            f.write(f"#dataset={dataset}\n")
-                            for scene in scenes:
-                                f.write(scene["entityId"] + "\n")
-                    elif file.endswith(".json"):
-                        with open(file, "w", encoding="utf-8") as f:
-                            json.dump(scenes, f, indent=4)
-                    elif file.endswith((".gpkg", ".geojson", ".shp", ".html")):
-                        gdf = utils.convert_response_to_gdf(scenes)
-                        if file.endswith(".html"):
-                            utils.save_in_html(gdf, file)
-                        else:
-                            utils.save_in_gfile(gdf, file)
+            for file in output_files:
+                directory = os.path.dirname(file)
+                if directory:
+                    os.makedirs(directory, exist_ok=True)
+
+                if file.endswith(".txt"):
+                    with open(file, "w", encoding="utf-8") as f:
+                        f.write(f"#dataset={dataset}\n")
+                        for scene in scenes:
+                            f.write(scene["entityId"] + "\n")
+                elif file.endswith(".json"):
+                    with open(file, "w", encoding="utf-8") as f:
+                        json.dump(scenes, f, indent=4)
+                elif file.endswith((".gpkg", ".geojson", ".shp", ".html")):
+                    gdf = utils.convert_response_to_gdf(scenes)
+                    if file.endswith(".html"):
+                        utils.save_in_html(gdf, file)
+                    else:
+                        utils.save_in_gfile(gdf, file)
     except USGSInvalidDataset:
         with API(username, token) as api:
             datasets = api.dataset_names()

--- a/usgsxplore/utils.py
+++ b/usgsxplore/utils.py
@@ -87,7 +87,9 @@ def save_in_html(gdf: gpd.GeoDataFrame, html_file: str = "scenes.html") -> None:
     gdf["centroid"] = gdf.to_crs(epsg=3857).geometry.centroid.to_crs(epsg=4326)
     center = gdf["centroid"].y.mean(), gdf["centroid"].x.mean()
 
-    m = folium.Map(location=center, zoom_start=3)
+    # OpenStreetMap's default tiles now reject folium/leaflet traffic under its
+    # tile usage policy, so use Esri's freely embeddable satellite basemap instead.
+    m = folium.Map(location=center, zoom_start=3, tiles="Esri.WorldImagery")
     first_col_name = gdf.columns[0]
 
     # add footprint on the map
@@ -116,17 +118,21 @@ def read_textfile(textfile: str) -> tuple[str | None, list[str]]:
     dataset = None
 
     with open(textfile, encoding="utf-8") as file:
-        first_line = file.readline().strip()
-        if first_line.startswith("#"):
-            spl = first_line.split("=", maxsplit=1)
-            if len(spl) == 2 and "dataset" in spl[0]:
-                dataset = spl[1].strip()
+        lines = file.readlines()
 
-        # loop in other line and don't take the comment
-        for line in file:
-            if not line.strip().startswith("#"):
-                spl = line.split("#", maxsplit=1)
-                list_ids.append(spl[0].strip())
+    if lines and lines[0].strip().startswith("#"):
+        spl = lines[0].strip().split("=", maxsplit=1)
+        if len(spl) == 2 and "dataset" in spl[0]:
+            dataset = spl[1].strip()
+        lines = lines[1:]
+
+    # loop in other line and don't take the comment
+    for line in lines:
+        if not line.strip().startswith("#"):
+            spl = line.split("#", maxsplit=1)
+            entity_id = spl[0].strip()
+            if entity_id:
+                list_ids.append(entity_id)
     return (dataset, list_ids)
 
 


### PR DESCRIPTION
## Summary
- Add `-e/--entity-ids-file` to `search`: fetch metadata directly for a list of entity IDs instead of running a filtered search
- Fix `read_textfile` silently dropping the first entity ID when the file has no `#dataset=` header
- Fix HTML map export using OSM tiles, now blocked by their usage policy — switched to Esri satellite tiles
- Add `--version` to the CLI

